### PR TITLE
Clean up implementation

### DIFF
--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -16,10 +16,12 @@
 #     The Pytest_ROOT environment variable or CMake variable can be used to
 #     prepend a custom search path.
 #     (https://cmake.org/cmake/help/latest/policy/CMP0074.html)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 include(FindPackageHandleStandardArgs)
 
 find_program(PYTEST_EXECUTABLE NAMES pytest)
+mark_as_advanced(PYTEST_EXECUTABLE)
 
 if(PYTEST_EXECUTABLE)
     execute_process(
@@ -32,11 +34,7 @@ if(PYTEST_EXECUTABLE)
     if (_version MATCHES "pytest version ([0-9]+\\.[0-9]+\\.[0-9]+),")
         set(PYTEST_VERSION "${CMAKE_MATCH_1}")
     endif()
-
-    mark_as_advanced(_version)
 endif()
-
-mark_as_advanced(PYTEST_EXECUTABLE PYTEST_VERSION)
 
 find_package_handle_standard_args(
     Pytest
@@ -44,10 +42,12 @@ find_package_handle_standard_args(
         PYTEST_EXECUTABLE
     VERSION_VAR
         PYTEST_VERSION
+    HANDLE_COMPONENTS
+    HANDLE_VERSION_RANGE
 )
 
 if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
-    add_executable(Pytest::Pytest IMPORTED GLOBAL)
+    add_executable(Pytest::Pytest IMPORTED)
     set_target_properties(Pytest::Pytest
         PROPERTIES
             IMPORTED_LOCATION "${PYTEST_EXECUTABLE}")
@@ -120,15 +120,12 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             -D "WORKING_DIRECTORY=${_WORKING_DIRECTORY}"
             -D "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
             -D "CTEST_FILE=${_tests_file}"
-            -P "${_PYTEST_DISCOVER_TESTS_SCRIPT}")
+            -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/PytestAddTests.cmake")
 
         # Add discovered tests to directory TEST_INCLUDE_FILES
         set_property(DIRECTORY
             APPEND PROPERTY TEST_INCLUDE_FILES "${_tests_file}")
 
     endfunction()
-
-    set(_PYTEST_DISCOVER_TESTS_SCRIPT
-        ${CMAKE_CURRENT_LIST_DIR}/PytestAddTests.cmake)
 
 endif()

--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -1,5 +1,5 @@
 # Wrapper used to create individual CTest tests from Pytest tests.
-cmake_minimum_required(VERSION ${CMAKE_VERSION})
+cmake_minimum_required(VERSION 3.20...3.25)
 
 if(CMAKE_SCRIPT_MODE_FILE)
 
@@ -13,15 +13,15 @@ if(CMAKE_SCRIPT_MODE_FILE)
     if (BUNDLE_TESTS)
         string(APPEND _content
             "add_test(\n"
-            "    ${TEST_GROUP_NAME}\n"
+            "    \"${TEST_GROUP_NAME}\"\n"
             "    ${PYTEST_EXECUTABLE} \"${WORKING_DIRECTORY}\"\n"
             ")\n"
             "set_tests_properties(\n"
-            "     ${TEST_GROUP_NAME} PROPERTIES\n"
+            "     \"${TEST_GROUP_NAME}\" PROPERTIES\n"
             "     ENVIRONMENT \"${LIB_ENV_PATH}=${LIBRARY_PATH}\"\n"
             ")\n"
             "set_tests_properties(\n"
-            "     ${TEST_GROUP_NAME}\n"
+            "     \"${TEST_GROUP_NAME}\"\n"
             "     APPEND PROPERTIES\n"
             "     ENVIRONMENT \"PYTHONPATH=${PYTHON_PATH}\"\n"
             ")\n"
@@ -73,15 +73,15 @@ if(CMAKE_SCRIPT_MODE_FILE)
 
             string(APPEND _content
                 "add_test(\n"
-                "    ${test_name}\n"
+                "    \"${test_name}\"\n"
                 "    ${PYTEST_EXECUTABLE} \"${test_case}\"\n"
                 ")\n"
                 "set_tests_properties(\n"
-                "     ${test_name} PROPERTIES\n"
+                "     \"${test_name}\" PROPERTIES\n"
                 "     ENVIRONMENT \"${LIB_ENV_PATH}=${LIBRARY_PATH}\"\n"
                 ")\n"
                 "set_tests_properties(\n"
-                "     ${test_name}\n"
+                "     \"${test_name}\"\n"
                 "     APPEND PROPERTIES\n"
                 "     ENVIRONMENT \"PYTHONPATH=${PYTHON_PATH}\"\n"
                 ")\n"


### PR DESCRIPTION
This PR cleans up a few pieces of the implementation, without changing the interface. It sets CMake 3.20 as a minimum version, but enables policies through 3.25. It also adds missing quotes, abstains from promoting the Pytest::Pytest target to the global scope, drops some unused mark_as_advanced calls, and enables version ranges and component checking in find_package.

Fixes #1