### PR TITLE
Send warning instead of fatal error when no tests are found.

### DIFF
--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -92,7 +92,7 @@ if(CMAKE_SCRIPT_MODE_FILE)
         endforeach()
 
         if(NOT _content)
-            message(FATAL_ERROR "No Python tests have been discovered.")
+            message(WARNING "No Python tests have been discovered.")
         endif()
     endif()
 


### PR DESCRIPTION
Closes #8 