### PR TITLE
Ensure compatibility with Python 2.7

### DIFF
--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -63,6 +63,6 @@ runs:
                     --options=boost:without_timer=True \
                     --options=boost:without_type_erasure=True \
                     --options=boost:without_wave=True \
-                    --options=boost:python_executable=${{ inputs.python }} \
+                    --options=boost:python_executable=$(which ${{ inputs.python }}) \
                     --generator=cmake_find_package \
                     --build=missing 

--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -57,6 +57,6 @@ runs:
                     --options=boost:without_timer=True \
                     --options=boost:without_type_erasure=True \
                     --options=boost:without_wave=True \
+                    --options=boost:python_executable=${{ inputs.python }} \
                     --generator=cmake_find_package \
-                    --python_executable=${{ inputs.python }} \
                     --build=missing 

--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -4,6 +4,8 @@ description: "Install Boost "
 inputs:
     platform:
         description: "Indicate the identifier of the platform"
+    python:
+        description: "Path to python executable"
 
 runs:
     using: composite
@@ -56,4 +58,5 @@ runs:
                     --options=boost:without_type_erasure=True \
                     --options=boost:without_wave=True \
                     --generator=cmake_find_package \
+                    --python_executable=${{ inputs.python }} \
                     --build=missing 

--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -63,6 +63,6 @@ runs:
                     --options=boost:without_timer=True \
                     --options=boost:without_type_erasure=True \
                     --options=boost:without_wave=True \
-                    --options=boost:python_executable=$(which ${{ inputs.python }}) \
+                    --options=boost:python_executable=${{ inputs.python }} \
                     --generator=cmake_find_package \
                     --build=missing 

--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -13,7 +13,7 @@ runs:
         -   name: Install conan
             shell: bash
             run: |
-                python3 -m pip install conan numpy
+                python3 -m pip install conan
                 conan profile new default --detect
                 conan profile show default
 
@@ -23,6 +23,12 @@ runs:
             run: |
                 conan profile update settings.compiler.libcxx=libstdc++11 default
                 conan profile show default
+
+        -   name: Install numpy
+            shell: bash
+            # For some reason, boost python cannot be installed without numpy
+            # https://github.com/conan-io/conan-center-index/issues/10953
+            run: ${{ inputs.python }} -m pip install numpy
 
         -   name: Install Boost Python
             shell: bash

--- a/.github/actions/install-boost/action.yml
+++ b/.github/actions/install-boost/action.yml
@@ -1,0 +1,59 @@
+name: install-boost
+description: "Install Boost "
+
+inputs:
+    platform:
+        description: "Indicate the identifier of the platform"
+
+runs:
+    using: composite
+    steps:
+        -   name: Install conan
+            shell: bash
+            run: |
+                python3 -m pip install conan numpy
+                conan profile new default --detect
+                conan profile show default
+
+        -   name: Setup compiler (Linux only)
+            shell: bash
+            if: ${{ inputs.platform == 'ubuntu' }}
+            run: |
+                conan profile update settings.compiler.libcxx=libstdc++11 default
+                conan profile show default
+
+        -   name: Install Boost Python
+            shell: bash
+            run: |
+                conan install boost/1.80.0@ \
+                    --options=boost:without_python=False \
+                    --options=boost:without_atomic=True \
+                    --options=boost:without_chrono=True \
+                    --options=boost:without_container=True \
+                    --options=boost:without_context=True \
+                    --options=boost:without_contract=True \
+                    --options=boost:without_coroutine=True \
+                    --options=boost:without_date_time=True \
+                    --options=boost:without_exception=True \
+                    --options=boost:without_fiber=True \
+                    --options=boost:without_filesystem=True \
+                    --options=boost:without_graph=True \
+                    --options=boost:without_iostreams=True \
+                    --options=boost:without_json=True \
+                    --options=boost:without_locale=True \
+                    --options=boost:without_log=True \
+                    --options=boost:without_math=True \
+                    --options=boost:without_nowide=True \
+                    --options=boost:without_program_options=True \
+                    --options=boost:without_random=True \
+                    --options=boost:without_regex=True \
+                    --options=boost:without_serialization=True \
+                    --options=boost:without_stacktrace=True \
+                    --options=boost:without_system=True \
+                    --options=boost:without_test=True \
+                    --options=boost:without_thread=True \
+                    --options=boost:without_timer=True \
+                    --options=boost:without_type_erasure=True \
+                    --options=boost:without_wave=True \
+                    --generator=cmake_find_package \
+                    --build=missing 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,11 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Boost
-                uses: ./.github/actions/install-boost
+            -   name: Install Boost Python
+                uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
+                    python: ${which python}
 
             -   name: Install pytest + pytest-cmake
                 run: pip install . pytest==${{ matrix.pytest }}.*
@@ -94,8 +95,8 @@ jobs:
             -   uses: actions/setup-python@v4
                 with:
                     python-version: |
-                        3.10
                         2.7
+                        3.10
 
             -   uses: actions/checkout@v3
 
@@ -113,10 +114,11 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Boost
-                uses: ./.github/actions/install-boost
+            -   name: Install Boost Python
+                uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
+                    python: ${which python2}
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,57 +49,17 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Pytest + Conan
+            -   name: Install Pytest
                 shell: bash
-                run: |
-                    pip install \
-                        pytest==${{ matrix.pytest }}.* \
-                        conan numpy
-                    conan profile new default --detect
-                    conan profile show default
-                    which pytest
+                run: pip install pytest==${{ matrix.pytest }}.*
 
-            -   name: Setup compiler (Linux only)
-                if: ${{ matrix.os == 'ubuntu' }}
-                run: |
-                    conan profile update settings.compiler.libcxx=libstdc++11 default
-                    conan profile show default
-
-            -   name: Install Boost Python
-                shell: bash
-                run: |
-                    conan install boost/1.80.0@ \
-                        --options=boost:without_python=False \
-                        --options=boost:without_atomic=True \
-                        --options=boost:without_chrono=True \
-                        --options=boost:without_container=True \
-                        --options=boost:without_context=True \
-                        --options=boost:without_contract=True \
-                        --options=boost:without_coroutine=True \
-                        --options=boost:without_date_time=True \
-                        --options=boost:without_exception=True \
-                        --options=boost:without_fiber=True \
-                        --options=boost:without_filesystem=True \
-                        --options=boost:without_graph=True \
-                        --options=boost:without_iostreams=True \
-                        --options=boost:without_json=True \
-                        --options=boost:without_locale=True \
-                        --options=boost:without_log=True \
-                        --options=boost:without_math=True \
-                        --options=boost:without_nowide=True \
-                        --options=boost:without_program_options=True \
-                        --options=boost:without_random=True \
-                        --options=boost:without_regex=True \
-                        --options=boost:without_serialization=True \
-                        --options=boost:without_stacktrace=True \
-                        --options=boost:without_system=True \
-                        --options=boost:without_test=True \
-                        --options=boost:without_thread=True \
-                        --options=boost:without_timer=True \
-                        --options=boost:without_type_erasure=True \
-                        --options=boost:without_wave=True \
-                        --generator=cmake_find_package \
-                        --build=missing 
+            -   name: Build Boost
+                uses: egor-tensin/build-boost@v1
+                with:
+                    version: 1.80.0
+                    libraries: python
+                    platform: x64
+                    configuration: Release
 
             -   name: Install pytest-cmake
                 run: pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,71 +7,71 @@ on:
         branches: [ main ]
 
 jobs:
-    test:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ "ubuntu", "macos", "windows" ]
-                cmake: [ "3.20", "3.25" ]
-                pytest: [ "6", "7" ]
-                python: [ "3.7", "3.8", "3.9", "3.10" ]
-                bundled: [ false, true ]
-
-        name: |
-            Pytest v${{ matrix.pytest }}
-            | CMake v${{ matrix.cmake }}
-            | ${{ matrix.os }}-py${{ matrix.python }}
-            | bundled: ${{ matrix.bundled }}
-
-        runs-on: "${{ matrix.os }}-latest"
-
-        env:
-            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
-
-        steps:
-            -   uses: actions/setup-python@v4
-                with:
-                    python-version: "${{ matrix.python }}"
-
-            -   uses: actions/checkout@v3
-
-            -   name: Setup cmake
-                uses: jwlawson/actions-setup-cmake@v1.13
-                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
-                with:
-                    cmake-version: "${{ matrix.cmake }}.x"
-
-            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
-                uses: jwlawson/actions-setup-cmake@v1.13
-                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
-                with:
-                    # Visual Studio 17 2022 requires at least CMake 3.21.
-                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
-                    cmake-version: "3.21.x"
-
-            -   name: Install Boost Python
-                uses: ./.github/actions/install-boost-python
-                with:
-                    platform: ${{ matrix.os }}
-                    python: $(which python)
-
-            -   name: Install pytest + pytest-cmake
-                run: pip install . pytest==${{ matrix.pytest }}.*
-
-            -   name: Build Example
-                shell: bash
-                run: |
-                    cmake --version
-                    cmake \
-                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-                        -S ./example \
-                        -B ./build
-                    cmake --build ./build --config Release
-
-            -   name: Run Tests
-                shell: bash
-                working-directory: build
-                run: ctest -VV
+#    test:
+#        strategy:
+#            fail-fast: false
+#            matrix:
+#                os: [ "ubuntu", "macos", "windows" ]
+#                cmake: [ "3.20", "3.25" ]
+#                pytest: [ "6", "7" ]
+#                python: [ "3.7", "3.8", "3.9", "3.10" ]
+#                bundled: [ false, true ]
+#
+#        name: |
+#            Pytest v${{ matrix.pytest }}
+#            | CMake v${{ matrix.cmake }}
+#            | ${{ matrix.os }}-py${{ matrix.python }}
+#            | bundled: ${{ matrix.bundled }}
+#
+#        runs-on: "${{ matrix.os }}-latest"
+#
+#        env:
+#            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
+#
+#        steps:
+#            -   uses: actions/setup-python@v4
+#                with:
+#                    python-version: "${{ matrix.python }}"
+#
+#            -   uses: actions/checkout@v3
+#
+#            -   name: Setup cmake
+#                uses: jwlawson/actions-setup-cmake@v1.13
+#                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
+#                with:
+#                    cmake-version: "${{ matrix.cmake }}.x"
+#
+#            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
+#                uses: jwlawson/actions-setup-cmake@v1.13
+#                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
+#                with:
+#                    # Visual Studio 17 2022 requires at least CMake 3.21.
+#                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
+#                    cmake-version: "3.21.x"
+#
+#            -   name: Install Boost Python
+#                uses: ./.github/actions/install-boost-python
+#                with:
+#                    platform: ${{ matrix.os }}
+#                    python: python3
+#
+#            -   name: Install pytest + pytest-cmake
+#                run: pip install . pytest==${{ matrix.pytest }}.*
+#
+#            -   name: Build Example
+#                shell: bash
+#                run: |
+#                    cmake --version
+#                    cmake \
+#                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+#                        -S ./example \
+#                        -B ./build
+#                    cmake --build ./build --config Release
+#
+#            -   name: Run Tests
+#                shell: bash
+#                working-directory: build
+#                run: ctest -VV
 
     test-python27:
         strategy:
@@ -118,7 +118,7 @@ jobs:
                 uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
-                    python: $(which python2)
+                    python: python2
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*
@@ -129,6 +129,7 @@ jobs:
                     cmake --version
                     cmake \
                         -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+                        -DPython_EXECUTABLE="$(which python2)" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
                 os: [ "ubuntu", "macos", "windows" ]
                 cmake: [ "3.20", "3.25" ]
                 pytest: [ "6", "7" ]
-                python: [ "2.7", "3.7", "3.8", "3.9", "3.10" ]
+                python: [ "3.7", "3.8", "3.9", "3.10" ]
                 bundled: [ false, true ]
 
         name: |
@@ -54,6 +54,115 @@ jobs:
                 run: |
                     pip install \
                         pytest==${{ matrix.pytest }}.* \
+                        conan numpy
+                    conan profile new default --detect
+                    conan profile show default
+                    which pytest
+
+            -   name: Setup compiler (Linux only)
+                if: ${{ matrix.os == 'ubuntu' }}
+                run: |
+                    conan profile update settings.compiler.libcxx=libstdc++11 default
+                    conan profile show default
+
+            -   name: Install Boost Python
+                shell: bash
+                run: |
+                    conan install boost/1.80.0@ \
+                        --options=boost:without_python=False \
+                        --options=boost:without_atomic=True \
+                        --options=boost:without_chrono=True \
+                        --options=boost:without_container=True \
+                        --options=boost:without_context=True \
+                        --options=boost:without_contract=True \
+                        --options=boost:without_coroutine=True \
+                        --options=boost:without_date_time=True \
+                        --options=boost:without_exception=True \
+                        --options=boost:without_fiber=True \
+                        --options=boost:without_filesystem=True \
+                        --options=boost:without_graph=True \
+                        --options=boost:without_iostreams=True \
+                        --options=boost:without_json=True \
+                        --options=boost:without_locale=True \
+                        --options=boost:without_log=True \
+                        --options=boost:without_math=True \
+                        --options=boost:without_nowide=True \
+                        --options=boost:without_program_options=True \
+                        --options=boost:without_random=True \
+                        --options=boost:without_regex=True \
+                        --options=boost:without_serialization=True \
+                        --options=boost:without_stacktrace=True \
+                        --options=boost:without_system=True \
+                        --options=boost:without_test=True \
+                        --options=boost:without_thread=True \
+                        --options=boost:without_timer=True \
+                        --options=boost:without_type_erasure=True \
+                        --options=boost:without_wave=True \
+                        --generator=cmake_find_package \
+                        --build=missing 
+
+            -   name: Install pytest-cmake
+                run: pip install .
+
+            -   name: Build Example
+                shell: bash
+                run: |
+                    cmake --version
+                    cmake \
+                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+                        -S ./example \
+                        -B ./build
+                    cmake --build ./build --config Release
+
+            -   name: Run Tests
+                shell: bash
+                working-directory: build
+                run: ctest -VV
+
+    test-python2.7:
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ "ubuntu", "macos", "windows" ]
+                cmake: [ "3.20", "3.25" ]
+                bundled: [ false, true ]
+
+        name: |
+            Pytest v4 | CMake v${{ matrix.cmake }}
+            | ${{ matrix.os }}-py2.7
+            | bundled: ${{ matrix.bundled }}
+
+        runs-on: "${{ matrix.os }}-latest"
+
+        env:
+            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
+
+        steps:
+            -   uses: actions/setup-python@v4
+                with:
+                    python-version: "2.7"
+
+            -   uses: actions/checkout@v3
+
+            -   name: Setup cmake
+                uses: jwlawson/actions-setup-cmake@v1.13
+                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
+                with:
+                    cmake-version: "${{ matrix.cmake }}.x"
+
+            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
+                uses: jwlawson/actions-setup-cmake@v1.13
+                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
+                with:
+                    # Visual Studio 17 2022 requires at least CMake 3.21.
+                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
+                    cmake-version: "3.21.x"
+
+            -   name: Install Pytest + Conan
+                shell: bash
+                run: |
+                    pip install \
+                        pytest==4.* \
                         conan numpy
                     conan profile new default --detect
                     conan profile show default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 #                uses: ./.github/actions/install-boost-python
 #                with:
 #                    platform: ${{ matrix.os }}
-#                    python: python3
+#                    python: $(which python)
 #
 #            -   name: Install pytest + pytest-cmake
 #                run: pip install . pytest==${{ matrix.pytest }}.*
@@ -118,7 +118,7 @@ jobs:
                 uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
-                    python: python2
+                    python: $(which python2.7)
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*
@@ -129,7 +129,7 @@ jobs:
                     cmake --version
                     cmake \
                         -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-                        -DPython_EXECUTABLE="$(which python2)" \
+                        -DPython_EXECUTABLE="$(which python2.7)" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,57 +158,17 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Pytest + Conan
+            -   name: Install Pytest
                 shell: bash
-                run: |
-                    pip install \
-                        pytest==4.* \
-                        conan numpy
-                    conan profile new default --detect
-                    conan profile show default
-                    which pytest
+                run: pip install pytest==4.*
 
-            -   name: Setup compiler (Linux only)
-                if: ${{ matrix.os == 'ubuntu' }}
-                run: |
-                    conan profile update settings.compiler.libcxx=libstdc++11 default
-                    conan profile show default
-
-            -   name: Install Boost Python
-                shell: bash
-                run: |
-                    conan install boost/1.80.0@ \
-                        --options=boost:without_python=False \
-                        --options=boost:without_atomic=True \
-                        --options=boost:without_chrono=True \
-                        --options=boost:without_container=True \
-                        --options=boost:without_context=True \
-                        --options=boost:without_contract=True \
-                        --options=boost:without_coroutine=True \
-                        --options=boost:without_date_time=True \
-                        --options=boost:without_exception=True \
-                        --options=boost:without_fiber=True \
-                        --options=boost:without_filesystem=True \
-                        --options=boost:without_graph=True \
-                        --options=boost:without_iostreams=True \
-                        --options=boost:without_json=True \
-                        --options=boost:without_locale=True \
-                        --options=boost:without_log=True \
-                        --options=boost:without_math=True \
-                        --options=boost:without_nowide=True \
-                        --options=boost:without_program_options=True \
-                        --options=boost:without_random=True \
-                        --options=boost:without_regex=True \
-                        --options=boost:without_serialization=True \
-                        --options=boost:without_stacktrace=True \
-                        --options=boost:without_system=True \
-                        --options=boost:without_test=True \
-                        --options=boost:without_thread=True \
-                        --options=boost:without_timer=True \
-                        --options=boost:without_type_erasure=True \
-                        --options=boost:without_wave=True \
-                        --generator=cmake_find_package \
-                        --build=missing 
+            -   name: Build Boost
+                uses: egor-tensin/build-boost@v1
+                with:
+                    version: 1.80.0
+                    libraries: python
+                    platform: x64
+                    configuration: Release
 
             -   name: Install pytest-cmake
                 run: pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,29 +49,64 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Pytest
+            -   name: Install conan
                 shell: bash
-                run: pip install pytest==${{ matrix.pytest }}.*
+                run: |
+                    pip install conan numpy
+                    conan profile new default --detect
+                    conan profile show default
 
-            -   name: Build Boost
-                id: boost
-                uses: egor-tensin/build-boost@v1
-                with:
-                    version: 1.80.0
-                    libraries: python
-                    platform: x64
-                    configuration: Release
+            -   name: Setup compiler (Linux only)
+                if: ${{ matrix.os == 'ubuntu' }}
+                run: |
+                    conan profile update settings.compiler.libcxx=libstdc++11 default
+                    conan profile show default
 
-            -   name: Install pytest-cmake
-                run: pip install .
+            -   name: Install Boost Python
+                shell: bash
+                run: |
+                    conan install boost/1.80.0@ \
+                        --options=boost:without_python=False \
+                        --options=boost:without_atomic=True \
+                        --options=boost:without_chrono=True \
+                        --options=boost:without_container=True \
+                        --options=boost:without_context=True \
+                        --options=boost:without_contract=True \
+                        --options=boost:without_coroutine=True \
+                        --options=boost:without_date_time=True \
+                        --options=boost:without_exception=True \
+                        --options=boost:without_fiber=True \
+                        --options=boost:without_filesystem=True \
+                        --options=boost:without_graph=True \
+                        --options=boost:without_iostreams=True \
+                        --options=boost:without_json=True \
+                        --options=boost:without_locale=True \
+                        --options=boost:without_log=True \
+                        --options=boost:without_math=True \
+                        --options=boost:without_nowide=True \
+                        --options=boost:without_program_options=True \
+                        --options=boost:without_random=True \
+                        --options=boost:without_regex=True \
+                        --options=boost:without_serialization=True \
+                        --options=boost:without_stacktrace=True \
+                        --options=boost:without_system=True \
+                        --options=boost:without_test=True \
+                        --options=boost:without_thread=True \
+                        --options=boost:without_timer=True \
+                        --options=boost:without_type_erasure=True \
+                        --options=boost:without_wave=True \
+                        --generator=cmake_find_package \
+                        --build=missing 
+
+            -   name: Install pytest + pytest-cmake
+                run: pip install . pytest==${{ matrix.pytest }}.
 
             -   name: Build Example
                 shell: bash
                 run: |
                     cmake --version
                     cmake \
-                        -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
-                        -D "BOOST_LIBRARYDIR=${{ steps.boost.outputs.librarydir }}" \
+                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release
@@ -102,7 +137,7 @@ jobs:
         steps:
             -   uses: actions/setup-python@v4
                 with:
-                    python-version: "2.7"
+                    python-version: 2.7 | 3.8
 
             -   uses: actions/checkout@v3
 
@@ -120,29 +155,64 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install Pytest
+            -   name: Install conan
                 shell: bash
-                run: pip install pytest==4.*
+                run: |
+                    python2 -m pip install conan numpy
+                    conan profile new default --detect
+                    conan profile show default
 
-            -   name: Build Boost
-                id: boost
-                uses: egor-tensin/build-boost@v1
-                with:
-                    version: 1.80.0
-                    libraries: python
-                    platform: x64
-                    configuration: Release
+            -   name: Setup compiler (Linux only)
+                if: ${{ matrix.os == 'ubuntu' }}
+                run: |
+                    conan profile update settings.compiler.libcxx=libstdc++11 default
+                    conan profile show default
 
-            -   name: Install pytest-cmake
-                run: pip install .
+            -   name: Install Boost Python
+                shell: bash
+                run: |
+                    conan install boost/1.80.0@ \
+                        --options=boost:without_python=False \
+                        --options=boost:without_atomic=True \
+                        --options=boost:without_chrono=True \
+                        --options=boost:without_container=True \
+                        --options=boost:without_context=True \
+                        --options=boost:without_contract=True \
+                        --options=boost:without_coroutine=True \
+                        --options=boost:without_date_time=True \
+                        --options=boost:without_exception=True \
+                        --options=boost:without_fiber=True \
+                        --options=boost:without_filesystem=True \
+                        --options=boost:without_graph=True \
+                        --options=boost:without_iostreams=True \
+                        --options=boost:without_json=True \
+                        --options=boost:without_locale=True \
+                        --options=boost:without_log=True \
+                        --options=boost:without_math=True \
+                        --options=boost:without_nowide=True \
+                        --options=boost:without_program_options=True \
+                        --options=boost:without_random=True \
+                        --options=boost:without_regex=True \
+                        --options=boost:without_serialization=True \
+                        --options=boost:without_stacktrace=True \
+                        --options=boost:without_system=True \
+                        --options=boost:without_test=True \
+                        --options=boost:without_thread=True \
+                        --options=boost:without_timer=True \
+                        --options=boost:without_type_erasure=True \
+                        --options=boost:without_wave=True \
+                        --generator=cmake_find_package \
+                        --build=missing 
+
+            -   name: Install pytest + pytest-cmake
+                run: python3 -m pip install . pytest==4.*
 
             -   name: Build Example
                 shell: bash
                 run: |
                     cmake --version
                     cmake \
-                        -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
-                        -D "BOOST_LIBRARYDIR=${{ steps.boost.outputs.librarydir }}" \
+                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,77 +7,77 @@ on:
         branches: [ main ]
 
 jobs:
-#    test:
-#        strategy:
-#            fail-fast: false
-#            matrix:
-#                os: [ "ubuntu", "macos", "windows" ]
-#                cmake: [ "3.20", "3.25" ]
-#                pytest: [ "6", "7" ]
-#                python: [ "3.7", "3.8", "3.9", "3.10" ]
-#                bundled: [ false, true ]
-#
-#        name: |
-#            Pytest v${{ matrix.pytest }}
-#            | CMake v${{ matrix.cmake }}
-#            | ${{ matrix.os }}-py${{ matrix.python }}
-#            | bundled: ${{ matrix.bundled }}
-#
-#        runs-on: "${{ matrix.os }}-latest"
-#
-#        env:
-#            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
-#
-#        steps:
-#            -   uses: actions/setup-python@v4
-#                with:
-#                    python-version: "${{ matrix.python }}"
-#
-#            -   uses: actions/checkout@v3
-#
-#            -   name: Setup cmake
-#                uses: jwlawson/actions-setup-cmake@v1.13
-#                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
-#                with:
-#                    cmake-version: "${{ matrix.cmake }}.x"
-#
-#            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
-#                uses: jwlawson/actions-setup-cmake@v1.13
-#                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
-#                with:
-#                    # Visual Studio 17 2022 requires at least CMake 3.21.
-#                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
-#                    cmake-version: "3.21.x"
-#
-#            -   name: Install Boost Python
-#                uses: ./.github/actions/install-boost-python
-#                with:
-#                    platform: ${{ matrix.os }}
-#                    python: $(which python)
-#
-#            -   name: Install pytest + pytest-cmake
-#                run: pip install . pytest==${{ matrix.pytest }}.*
-#
-#            -   name: Build Example
-#                shell: bash
-#                run: |
-#                    cmake --version
-#                    cmake \
-#                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-#                        -S ./example \
-#                        -B ./build
-#                    cmake --build ./build --config Release
-#
-#            -   name: Run Tests
-#                shell: bash
-#                working-directory: build
-#                run: ctest -VV
+    test:
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ "ubuntu", "macos", "windows" ]
+                cmake: [ "3.20", "3.25" ]
+                pytest: [ "6", "7" ]
+                python: [ "3.7", "3.8", "3.9", "3.10" ]
+                bundled: [ false, true ]
+
+        name: |
+            Pytest v${{ matrix.pytest }}
+            | CMake v${{ matrix.cmake }}
+            | ${{ matrix.os }}-py${{ matrix.python }}
+            | bundled: ${{ matrix.bundled }}
+
+        runs-on: "${{ matrix.os }}-latest"
+
+        env:
+            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
+
+        steps:
+            -   uses: actions/setup-python@v4
+                with:
+                    python-version: "${{ matrix.python }}"
+
+            -   uses: actions/checkout@v3
+
+            -   name: Setup cmake
+                uses: jwlawson/actions-setup-cmake@v1.13
+                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
+                with:
+                    cmake-version: "${{ matrix.cmake }}.x"
+
+            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
+                uses: jwlawson/actions-setup-cmake@v1.13
+                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
+                with:
+                    # Visual Studio 17 2022 requires at least CMake 3.21.
+                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
+                    cmake-version: "3.21.x"
+
+            -   name: Install Boost Python
+                uses: ./.github/actions/install-boost-python
+                with:
+                    platform: ${{ matrix.os }}
+                    python: $(which python)
+
+            -   name: Install pytest + pytest-cmake
+                run: pip install . pytest==${{ matrix.pytest }}.*
+
+            -   name: Build Example
+                shell: bash
+                run: |
+                    cmake --version
+                    cmake \
+                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+                        -S ./example \
+                        -B ./build
+                    cmake --build ./build --config Release
+
+            -   name: Run Tests
+                shell: bash
+                working-directory: build
+                run: ctest -VV
 
     test-python27:
         strategy:
             fail-fast: false
             matrix:
-                os: [ "ubuntu", "macos", "windows" ]
+                os: [ "ubuntu", "macos" ]
                 cmake: [ "3.20", "3.25" ]
                 bundled: [ false, true ]
 
@@ -118,7 +118,7 @@ jobs:
                 uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
-                    python: $(which python2.7)
+                    python: $(which python2)
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*
@@ -129,7 +129,7 @@ jobs:
                     cmake --version
                     cmake \
                         -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-                        -DPython_EXECUTABLE="$(which python2.7)" \
+                        -DPython_EXECUTABLE="$(which python2)" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
                 working-directory: build
                 run: ctest -VV
 
-    test-python2.7:
+    test-python27:
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
                         --build=missing 
 
             -   name: Install pytest + pytest-cmake
-                run: pip install . pytest==${{ matrix.pytest }}.
+                run: pip install . pytest==${{ matrix.pytest }}.*
 
             -   name: Build Example
                 shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
                     cmake --version
                     cmake \
                         -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
+                        -D "BOOST_LIBRARYDIR=${{ steps.boost.outputs.librarydir }}" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release
@@ -141,6 +142,7 @@ jobs:
                     cmake --version
                     cmake \
                         -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
+                        -D "BOOST_LIBRARYDIR=${{ steps.boost.outputs.librarydir }}" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
                 uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
-                    python: ${which python}
+                    python: $(which python)
 
             -   name: Install pytest + pytest-cmake
                 run: pip install . pytest==${{ matrix.pytest }}.*
@@ -118,7 +118,7 @@ jobs:
                 uses: ./.github/actions/install-boost-python
                 with:
                     platform: ${{ matrix.os }}
-                    python: ${which python2}
+                    python: $(which python2)
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
             -   name: Install conan
                 shell: bash
                 run: |
-                    python2 -m pip install conan numpy
+                    python3 -m pip install conan numpy
                     conan profile new default --detect
                     conan profile show default
 
@@ -207,7 +207,7 @@ jobs:
                         --build=missing 
 
             -   name: Install pytest + pytest-cmake
-                run: python3 -m pip install . pytest==4.*
+                run: python2 -m pip install . pytest==4.*
 
             -   name: Build Example
                 shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
                 run: pip install pytest==${{ matrix.pytest }}.*
 
             -   name: Build Boost
+                id: boost
                 uses: egor-tensin/build-boost@v1
                 with:
                     version: 1.80.0
@@ -69,7 +70,7 @@ jobs:
                 run: |
                     cmake --version
                     cmake \
-                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+                        -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release
@@ -123,6 +124,7 @@ jobs:
                 run: pip install pytest==4.*
 
             -   name: Build Boost
+                id: boost
                 uses: egor-tensin/build-boost@v1
                 with:
                     version: 1.80.0
@@ -138,7 +140,7 @@ jobs:
                 run: |
                     cmake --version
                     cmake \
-                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+                        -D "BOOST_ROOT=${{ steps.boost.outputs.root }}" \
                         -S ./example \
                         -B ./build
                     cmake --build ./build --config Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
                 os: [ "ubuntu", "macos", "windows" ]
                 cmake: [ "3.20", "3.25" ]
                 pytest: [ "6", "7" ]
-                python: [ "3.7", "3.8", "3.9", "3.10" ]
+                python: [ "2.7", "3.7", "3.8", "3.9", "3.10" ]
                 bundled: [ false, true ]
 
         name: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,9 @@ jobs:
         steps:
             -   uses: actions/setup-python@v4
                 with:
-                    python-version: 2.7 | 3.8
+                    python-version: |
+                        2.7
+                        3.10
 
             -   uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,54 +49,10 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install conan
-                shell: bash
-                run: |
-                    pip install conan numpy
-                    conan profile new default --detect
-                    conan profile show default
-
-            -   name: Setup compiler (Linux only)
-                if: ${{ matrix.os == 'ubuntu' }}
-                run: |
-                    conan profile update settings.compiler.libcxx=libstdc++11 default
-                    conan profile show default
-
-            -   name: Install Boost Python
-                shell: bash
-                run: |
-                    conan install boost/1.80.0@ \
-                        --options=boost:without_python=False \
-                        --options=boost:without_atomic=True \
-                        --options=boost:without_chrono=True \
-                        --options=boost:without_container=True \
-                        --options=boost:without_context=True \
-                        --options=boost:without_contract=True \
-                        --options=boost:without_coroutine=True \
-                        --options=boost:without_date_time=True \
-                        --options=boost:without_exception=True \
-                        --options=boost:without_fiber=True \
-                        --options=boost:without_filesystem=True \
-                        --options=boost:without_graph=True \
-                        --options=boost:without_iostreams=True \
-                        --options=boost:without_json=True \
-                        --options=boost:without_locale=True \
-                        --options=boost:without_log=True \
-                        --options=boost:without_math=True \
-                        --options=boost:without_nowide=True \
-                        --options=boost:without_program_options=True \
-                        --options=boost:without_random=True \
-                        --options=boost:without_regex=True \
-                        --options=boost:without_serialization=True \
-                        --options=boost:without_stacktrace=True \
-                        --options=boost:without_system=True \
-                        --options=boost:without_test=True \
-                        --options=boost:without_thread=True \
-                        --options=boost:without_timer=True \
-                        --options=boost:without_type_erasure=True \
-                        --options=boost:without_wave=True \
-                        --generator=cmake_find_package \
-                        --build=missing 
+            -   name: Install Boost
+                uses: ./.github/actions/install-boost
+                with:
+                    platform: ${{ matrix.os }}
 
             -   name: Install pytest + pytest-cmake
                 run: pip install . pytest==${{ matrix.pytest }}.*
@@ -138,8 +94,8 @@ jobs:
             -   uses: actions/setup-python@v4
                 with:
                     python-version: |
-                        2.7
                         3.10
+                        2.7
 
             -   uses: actions/checkout@v3
 
@@ -157,54 +113,10 @@ jobs:
                     # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
                     cmake-version: "3.21.x"
 
-            -   name: Install conan
-                shell: bash
-                run: |
-                    python3 -m pip install conan numpy
-                    conan profile new default --detect
-                    conan profile show default
-
-            -   name: Setup compiler (Linux only)
-                if: ${{ matrix.os == 'ubuntu' }}
-                run: |
-                    conan profile update settings.compiler.libcxx=libstdc++11 default
-                    conan profile show default
-
-            -   name: Install Boost Python
-                shell: bash
-                run: |
-                    conan install boost/1.80.0@ \
-                        --options=boost:without_python=False \
-                        --options=boost:without_atomic=True \
-                        --options=boost:without_chrono=True \
-                        --options=boost:without_container=True \
-                        --options=boost:without_context=True \
-                        --options=boost:without_contract=True \
-                        --options=boost:without_coroutine=True \
-                        --options=boost:without_date_time=True \
-                        --options=boost:without_exception=True \
-                        --options=boost:without_fiber=True \
-                        --options=boost:without_filesystem=True \
-                        --options=boost:without_graph=True \
-                        --options=boost:without_iostreams=True \
-                        --options=boost:without_json=True \
-                        --options=boost:without_locale=True \
-                        --options=boost:without_log=True \
-                        --options=boost:without_math=True \
-                        --options=boost:without_nowide=True \
-                        --options=boost:without_program_options=True \
-                        --options=boost:without_random=True \
-                        --options=boost:without_regex=True \
-                        --options=boost:without_serialization=True \
-                        --options=boost:without_stacktrace=True \
-                        --options=boost:without_system=True \
-                        --options=boost:without_test=True \
-                        --options=boost:without_thread=True \
-                        --options=boost:without_timer=True \
-                        --options=boost:without_type_erasure=True \
-                        --options=boost:without_wave=True \
-                        --generator=cmake_find_package \
-                        --build=missing 
+            -   name: Install Boost
+                uses: ./.github/actions/install-boost
+                with:
+                    platform: ${{ matrix.os }}
 
             -   name: Install pytest + pytest-cmake
                 run: python2 -m pip install . pytest==4.*

--- a/.versup.json
+++ b/.versup.json
@@ -15,5 +15,8 @@
     },
     "changelog": {
         "enabled": false
+    },
+    "commit": {
+        "mainbranch": "main"
     }
 }

--- a/.versup.json
+++ b/.versup.json
@@ -6,6 +6,12 @@
                 "version = \"[version]\""
             ]
         ],
+        "setup.py": [
+            [
+                "version=\"([\\d\\.]+)\"",
+                "version=\"[version]\""
+            ]
+        ],
         "doc/release/release_notes.rst": [
             [
                 ".. release:: Upcoming",

--- a/build_backend.py
+++ b/build_backend.py
@@ -1,0 +1,9 @@
+"""Custom backend to ensure compatibility with Python 2.7.
+"""
+
+import sys
+
+if sys.version_info[0] < 3:
+    from setuptools.build_meta import *
+else:
+    from hatchling.build import *

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,12 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: change
+
+        Added custom build backend to ensure compatibility with Python 2.7.
+
 .. release:: 0.1.0
     :date: 2022-12-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "pytest-cmake"
 version = "0.1.0"
 description = "Provide CMake module for Pytest"
 readme = "README.md"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5*, <4"
+requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 license = {file = "LICENSE"}
 keywords = ["cmake", "pytest", "development"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,18 @@
 [build-system]
 requires = [
-    "hatchling>=1.4",
+    "hatchling >= 1.4; python_version >= '3'",
+    "setuptools >= 44; python_version < '3'",
     "cmake >= 3.20, < 3.26"
 ]
-build-backend = "hatchling.build"
+build-backend = "build_backend"
+backend-path = ["."]
 
 [project]
 name = "pytest-cmake"
 version = "0.1.0"
 description = "Provide CMake module for Pytest"
 readme = "README.md"
-requires-python = ">=3.7, <4"
+requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5*, <4"
 license = {file = "LICENSE"}
 keywords = ["cmake", "pytest", "development"]
 authors = [
@@ -23,12 +25,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3 :: Only",
 ]
 
 [tool.hatch.build.hooks.custom]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 
 from setuptools import setup
-from setuptools.command.build_py import build_py
+from setuptools.command.install import install
 
 import os
 import subprocess
@@ -11,7 +11,7 @@ import subprocess
 ROOT = os.path.dirname(os.path.realpath(__file__))
 
 
-class BuildExtended(build_py):
+class CreateCmakeConfig(install):
     """Custom command to create and share pytest config."""
 
     def run(self):
@@ -54,6 +54,7 @@ class BuildExtended(build_py):
             )
 
         subprocess.call(["cmake", "-P", str(script_path), "-VV"])
+        return install.run(self)
 
 
 setup(
@@ -70,6 +71,6 @@ setup(
             ]
         )
     ],
-    cmdclass={"build_py": BuildExtended},
+    cmdclass={"install": CreateCmakeConfig},
     install_requires=["pytest >= 4, < 8"],
 )

--- a/setup.py
+++ b/setup.py
@@ -73,4 +73,5 @@ setup(
     ],
     cmdclass={"install": CreateCmakeConfig},
     install_requires=["pytest >= 4, < 8"],
+    setup_requires=["pytest >= 4, < 8"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,75 @@
+"""Setuptools config only used for Python 2.7 compatibility.
+"""
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+
+import os
+import subprocess
+
+
+ROOT = os.path.dirname(os.path.realpath(__file__))
+
+
+class BuildExtended(build_py):
+    """Custom command to create and share pytest config."""
+
+    def run(self):
+        """Execute builder."""
+        import pytest
+
+        build_path = os.path.join(ROOT, "build")
+        if not os.path.exists(build_path):
+            os.makedirs(build_path)
+
+        # CMake search procedure is limited to CMake package configuration files
+        # and does not work with modules. Hence, we are generating a
+        # configuration file based on the CMake modules created.
+        # https://cmake.org/cmake/help/latest/command/find_package.html
+        config_path = os.path.join(build_path, "PytestConfig.cmake")
+        with open(config_path, "w") as stream:
+            stream.write(
+                "include(${CMAKE_CURRENT_LIST_DIR}/FindPytest.cmake)\n"
+            )
+
+        # Generate CMake config version file for client to target a specific
+        # version of Pytest within CMake projects.
+        version_config_path = os.path.join(
+            build_path, "PytestConfigVersion.cmake"
+        )
+        script_path = os.path.join(
+            build_path, "PytestConfigVersionScript.cmake"
+        )
+        with open(script_path, "w") as stream:
+            stream.write(
+                "include(CMakePackageConfigHelpers)\n"
+                "write_basic_package_version_file(\n"
+                "    \"{path}\"\n"
+                "    VERSION {version}\n"
+                "    COMPATIBILITY AnyNewerVersion\n"
+                ")".format(
+                    path=str(version_config_path),
+                    version=pytest.__version__,
+                )
+            )
+
+        subprocess.call(["cmake", "-P", str(script_path), "-VV"])
+
+
+setup(
+    name="pytest-cmake",
+    version="0.1.0",
+    data_files=[
+        (
+            "share/Pytest/cmake",
+            [
+                "build/PytestConfig.cmake",
+                "build/PytestConfigVersion.cmake",
+                "cmake/FindPytest.cmake",
+                "cmake/PytestAddTests.cmake"
+            ]
+        )
+    ],
+    cmdclass={"build_py": BuildExtended},
+    install_requires=["pytest >= 4, < 8"],
+)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import subprocess
 
 
 ROOT = os.path.dirname(os.path.realpath(__file__))
+DEPENDENCIES = ["pytest >= 4, < 8"]
 
 
 class CreateCmakeConfig(install):
@@ -72,6 +73,6 @@ setup(
         )
     ],
     cmdclass={"install": CreateCmakeConfig},
-    install_requires=["pytest >= 4, < 8"],
-    setup_requires=["pytest >= 4, < 8"],
+    install_requires=DEPENDENCIES,
+    setup_requires=DEPENDENCIES,
 )


### PR DESCRIPTION
As a few projects still need to work for Python 2.7 (sigh), we need to provide a custom backend to use Setuptools if the Python interpreter version is under Python 3.
