### PR TITLE
Fix parsing of list environment variables for Windows.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,19 @@ on:
     pull_request:
         branches: [ main ]
 
+    # Run tests once a week on Sunday.
+    schedule:
+        - cron: "0 6 * * 0"
+
 jobs:
     test:
         strategy:
             fail-fast: false
             matrix:
                 os: [ "ubuntu", "macos", "windows" ]
-                cmake: [ "3.20", "3.25" ]
-                pytest: [ "6", "7" ]
-                python: [ "3.7", "3.8", "3.9", "3.10" ]
+                cmake: [ "3.20", "3.29" ]
+                pytest: [ "7", "8" ]
+                python: [ "3.8", "3.11", "3.12" ]
                 bundled: [ false, true ]
 
         name: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pytest CMake
 
 [![PyPi version](https://img.shields.io/pypi/v/pytest-cmake.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.python.org/pypi/pytest-cmake)
-[![CMake](https://img.shields.io/badge/CMake-3.20...3.25-blue.svg?logo=CMake&logoColor=blue)](https://cmake.org)
+[![CMake](https://img.shields.io/badge/CMake-3.20...3.29-blue.svg?logo=CMake&logoColor=blue)](https://cmake.org)
 [![Documentation](https://readthedocs.org/projects/pytest-cmake/badge/?version=stable)](https://pytest-cmake.readthedocs.io/en/stable/)
 [![Test](https://github.com/buddly27/pytest-cmake/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/buddly27/pytest-cmake/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -6,9 +6,10 @@ if(CMAKE_SCRIPT_MODE_FILE)
     # Set Cmake test file to execute each test.
     set(_content "")
 
-    # Convert input environment variable into list.
-    string(REPLACE "\\\;" ";" LIBRARY_PATH "${LIBRARY_PATH}")
-    string(REPLACE "\\\;" ";" PYTHON_PATH "${PYTHON_PATH}")
+    # Ensure that list environment variables are
+    # represented as a string on Windows.
+    string(REPLACE [[;]] [[\;]] LIBRARY_PATH "${LIBRARY_PATH}")
+    string(REPLACE [[;]] [[\;]] PYTHON_PATH "${PYTHON_PATH}")
 
     if (BUNDLE_TESTS)
         string(APPEND _content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling >= 1.4; python_version >= '3'",
     "setuptools >= 44; python_version < '3'",
-    "cmake >= 3.20, < 3.26"
+    "cmake >= 3.20, < 3.30"
 ]
 build-backend = "build_backend"
 backend-path = ["."]
@@ -19,7 +19,7 @@ authors = [
     {name = "Jeremy Retailleau", email = "jeremy.retailleau@gmail.com" }
 ]
 dependencies = [
-    "pytest >= 4, < 8",
+    "pytest >= 4, < 9",
 ]
 classifiers = [
     "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import subprocess
 
 
 ROOT = os.path.dirname(os.path.realpath(__file__))
-DEPENDENCIES = ["pytest >= 4, < 8"]
+DEPENDENCIES = ["pytest >= 4, < 9"]
 
 
 class CreateCmakeConfig(install):


### PR DESCRIPTION
- Ensure that list environment variable are represented as strings before serializing the CTest commands;
- Update CI script to support CMake 3.29 and Python 3.11.