### PR TITLE
Abort build on test collection failure

### DIFF
--- a/.github/actions/install-boost-python/action.yml
+++ b/.github/actions/install-boost-python/action.yml
@@ -2,67 +2,68 @@ name: install-boost
 description: "Install Boost "
 
 inputs:
-    platform:
-        description: "Indicate the identifier of the platform"
-    python:
-        description: "Path to python executable"
+  platform:
+    description: "Indicate the identifier of the platform"
+
+  python:
+    description: "Path to python executable"
 
 runs:
-    using: composite
-    steps:
-        -   name: Install conan
-            shell: bash
-            run: |
-                python3 -m pip install conan==1.*
-                conan profile new default --detect
-                conan profile show default
+  using: composite
+  steps:
+    - name: Install conan
+      shell: bash
+      run: |
+        python3 -m pip install conan==1.*
+        conan profile new default --detect
+        conan profile show default
 
-        -   name: Setup compiler (Linux only)
-            shell: bash
-            if: ${{ inputs.platform == 'ubuntu' }}
-            run: |
-                conan profile update settings.compiler.libcxx=libstdc++11 default
-                conan profile show default
+    - name: Setup compiler (Linux only)
+      shell: bash
+      if: ${{ inputs.platform == 'ubuntu' }}
+      run: |
+        conan profile update settings.compiler.libcxx=libstdc++11 default
+        conan profile show default
 
-        -   name: Install numpy
-            shell: bash
-            # For some reason, boost python cannot be installed without numpy
-            # https://github.com/conan-io/conan-center-index/issues/10953
-            run: ${{ inputs.python }} -m pip install numpy
+    - name: Install numpy
+      shell: bash
+      # For some reason, boost python cannot be installed without numpy
+      # https://github.com/conan-io/conan-center-index/issues/10953
+      run: ${{ inputs.python }} -m pip install numpy
 
-        -   name: Install Boost Python
-            shell: bash
-            run: |
-                conan install boost/1.80.0@ \
-                    --options=boost:without_python=False \
-                    --options=boost:without_atomic=True \
-                    --options=boost:without_chrono=True \
-                    --options=boost:without_container=True \
-                    --options=boost:without_context=True \
-                    --options=boost:without_contract=True \
-                    --options=boost:without_coroutine=True \
-                    --options=boost:without_date_time=True \
-                    --options=boost:without_exception=True \
-                    --options=boost:without_fiber=True \
-                    --options=boost:without_filesystem=True \
-                    --options=boost:without_graph=True \
-                    --options=boost:without_iostreams=True \
-                    --options=boost:without_json=True \
-                    --options=boost:without_locale=True \
-                    --options=boost:without_log=True \
-                    --options=boost:without_math=True \
-                    --options=boost:without_nowide=True \
-                    --options=boost:without_program_options=True \
-                    --options=boost:without_random=True \
-                    --options=boost:without_regex=True \
-                    --options=boost:without_serialization=True \
-                    --options=boost:without_stacktrace=True \
-                    --options=boost:without_system=True \
-                    --options=boost:without_test=True \
-                    --options=boost:without_thread=True \
-                    --options=boost:without_timer=True \
-                    --options=boost:without_type_erasure=True \
-                    --options=boost:without_wave=True \
-                    --options=boost:python_executable=${{ inputs.python }} \
-                    --generator=cmake_find_package \
-                    --build=missing 
+    - name: Install Boost Python
+      shell: bash
+      run: |
+        conan install boost/1.80.0@ \
+        --options=boost:without_python=False \
+        --options=boost:without_atomic=True \
+        --options=boost:without_chrono=True \
+        --options=boost:without_container=True \
+        --options=boost:without_context=True \
+        --options=boost:without_contract=True \
+        --options=boost:without_coroutine=True \
+        --options=boost:without_date_time=True \
+        --options=boost:without_exception=True \
+        --options=boost:without_fiber=True \
+        --options=boost:without_filesystem=True \
+        --options=boost:without_graph=True \
+        --options=boost:without_iostreams=True \
+        --options=boost:without_json=True \
+        --options=boost:without_locale=True \
+        --options=boost:without_log=True \
+        --options=boost:without_math=True \
+        --options=boost:without_nowide=True \
+        --options=boost:without_program_options=True \
+        --options=boost:without_random=True \
+        --options=boost:without_regex=True \
+        --options=boost:without_serialization=True \
+        --options=boost:without_stacktrace=True \
+        --options=boost:without_system=True \
+        --options=boost:without_test=True \
+        --options=boost:without_thread=True \
+        --options=boost:without_timer=True \
+        --options=boost:without_type_erasure=True \
+        --options=boost:without_wave=True \
+        --options=boost:python_executable=${{ inputs.python }} \
+        --generator=cmake_find_package \
+        --build=missing

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,40 @@
+name: PyPi Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  pypi-publish:
+    if: startsWith(github.ref, "refs/tags/")
+
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: |
+          python -m build --sdist
+
+      - name: Check metadata
+        run: twine check dist/*
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,79 +1,80 @@
-name: Test
+name: tests
 
 on:
-    push:
-        branches: [ main ]
-    pull_request:
-        branches: [ main ]
+  push:
+    branches: [ main ]
 
-    # Run tests once a week on Sunday.
-    schedule:
-        - cron: "0 6 * * 0"
+  pull_request:
+    branches: [ main ]
+
+  # Run tests once a week on Sunday.
+  schedule:
+    - cron: "0 6 * * 0"
 
 jobs:
-    test:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ "ubuntu", "macos", "windows" ]
-                cmake: [ "3.20", "3.29" ]
-                pytest: [ "7", "8" ]
-                python: [ "3.8", "3.11", "3.12" ]
-                bundled: [ false, true ]
+  run-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu", "macos", "windows" ]
+        cmake: [ "3.20", "3.29" ]
+        pytest: [ "7", "8" ]
+        python: [ "3.8", "3.11", "3.12" ]
+        bundled: [ false, true ]
 
-        name: |
-            Pytest v${{ matrix.pytest }}
-            | CMake v${{ matrix.cmake }}
-            | ${{ matrix.os }}-py${{ matrix.python }}
-            | bundled: ${{ matrix.bundled }}
+    name: |
+      Pytest v${{ matrix.pytest }}
+      | CMake v${{ matrix.cmake }}
+      | ${{ matrix.os }}-py${{ matrix.python }}
+      | bundled: ${{ matrix.bundled }}
 
-        runs-on: "${{ matrix.os }}-latest"
+    runs-on: "${{ matrix.os }}-latest"
 
-        env:
-            BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
+    env:
+      BUNDLE_PYTHON_TESTS: ${{ matrix.bundled }}
 
-        steps:
-            -   uses: actions/setup-python@v4
-                with:
-                    python-version: "${{ matrix.python }}"
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python }}"
 
-            -   uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-            -   name: Setup cmake
-                uses: jwlawson/actions-setup-cmake@v1.13
-                if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
-                with:
-                    cmake-version: "${{ matrix.cmake }}.x"
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2.0
+        if: ${{matrix.os != 'windows' || matrix.cmake != '3.20'}}
+        with:
+          cmake-version: "${{ matrix.cmake }}.x"
 
-            -   name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
-                uses: jwlawson/actions-setup-cmake@v1.13
-                if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
-                with:
-                    # Visual Studio 17 2022 requires at least CMake 3.21.
-                    # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
-                    cmake-version: "3.21.x"
+      - name: Setup cmake (Bump up CMake minimal version for Visual Studio 17 2022)
+        uses: jwlawson/actions-setup-cmake@v2.0
+        if: ${{matrix.os == 'windows' && matrix.cmake == '3.20'}}
+        with:
+          # Visual Studio 17 2022 requires at least CMake 3.21.
+          # https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html
+          cmake-version: "3.21.x"
 
-            -   name: Install Boost Python
-                uses: ./.github/actions/install-boost-python
-                with:
-                    platform: ${{ matrix.os }}
-                    python: $(which python)
+      - name: Install Boost Python
+        uses: ./.github/actions/install-boost-python
+        with:
+          platform: ${{ matrix.os }}
+          python: $(which python)
 
-            -   name: Install pytest + pytest-cmake
-                run: pip install . pytest==${{ matrix.pytest }}.*
+      - name: Install pytest + pytest-cmake
+        run: pip install . pytest==${{ matrix.pytest }}.*
 
-            -   name: Build Example
-                shell: bash
-                run: |
-                    cmake --version
-                    cmake \
-                        -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-                        -S ./example \
-                        -B ./build
-                    cmake --build ./build --config Release
+      - name: Build Example
+        shell: bash
+        run: |
+          cmake --version
+          cmake \
+            -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
+            -S ./example \
+            -B ./build
+          cmake --build ./build --config Release
 
-            -   name: Run Tests
-                shell: bash
-                working-directory: build
-                run: ctest -VV
+      - name: Run Tests
+        shell: bash
+        working-directory: build
+        run: ctest -VV
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,13 +4,23 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Updated CMake script now interrupts the build if the Python test
+        collection fails.
+
 .. release:: 0.4.1
     :date: 2024-03-17
 
     .. change:: fixed
 
         As of Hatching v1.22, dynamic dependencies during build time must
-        be imported lazily.
+        be imported lazily. Therefore, the backend script has been updated
+        to import 'pytest' only when the build hook is called.
+
+        seealso:: https://hatch.pypa.io/dev/plugins/build-hook/reference/#hatchling.builders.hooks.plugin.interface.BuildHookInterface.dependencies
 
 .. release:: 0.4.0
     :date: 2024-03-03

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [tool.hatch.build.hooks.custom]


### PR DESCRIPTION
Raise a fatal error with traceback if an error has occurred during the collection of Python tests.

Closes #17 