### PR TITLE
Ensure that rootdir is always a reasolved path.

### DIFF
--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -99,6 +99,8 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             set(_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         endif()
 
+        get_filename_component(_WORKING_DIRECTORY "${_WORKING_DIRECTORY}" REALPATH)
+
         # Override option by environment variable if available.
         if (DEFINED ENV{BUNDLE_PYTHON_TESTS})
             set(_BUNDLE_TESTS $ENV{BUNDLE_PYTHON_TESTS})

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,16 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+   .. change:: fixed
+
+        Updated test collection logic to ensure that the 'rootdir' is a
+        real path. Previously, running the tests from a symlinked directory
+        could result in errors when discovering 'conftests' configurations.
+
+        .. seealso:: https://github.com/pytest-dev/pytest/issues/12291
+
 .. release:: 0.5.1
     :date: 2024-03-17
 


### PR DESCRIPTION
Closes #25 