### PR TITLE
Improve path handling an serialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
 
   pull_request:
     branches: [ main ]
@@ -16,17 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu", "macos", "windows" ]
-        cmake: [ "3.20", "3.29" ]
         pytest: [ "7", "8" ]
+        cmake: [ "3.20", "3.29" ]
+        os: [ "ubuntu", "macos", "windows" ]
         python: [ "3.8", "3.11", "3.12" ]
         bundled: [ false, true ]
 
     name: |
-      Pytest v${{ matrix.pytest }}
-      | CMake v${{ matrix.cmake }}
-      | ${{ matrix.os }}-py${{ matrix.python }}
-      | bundled: ${{ matrix.bundled }}
+      v${{ matrix.pytest }}-${{ matrix.cmake }}
+      [${{ matrix.os }}-py${{ matrix.python }}]
+      ${{ matrix.bundled && '(bundled)' || '' }}
 
     runs-on: "${{ matrix.os }}-latest"
 
@@ -64,17 +63,12 @@ jobs:
         run: pip install . pytest==${{ matrix.pytest }}.*
 
       - name: Build Example
-        shell: bash
         run: |
           cmake --version
-          cmake \
-            -DCMAKE_MODULE_PATH:FILEPATH="$(pwd)" \
-            -S ./example \
-            -B ./build
+          cmake -D "CMAKE_MODULE_PATH:FILEPATH=${{ github.workspace }}" -S ./example -B ./build
           cmake --build ./build --config Release
 
       - name: Run Tests
-        shell: bash
         working-directory: build
-        run: ctest -VV
+        run: ctest -VV -C Release
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
 
   pull_request:
     branches: [ main ]

--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -60,41 +60,35 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             "LIBRARY_PATH_PREPEND;PYTHON_PATH_PREPEND;ENVIRONMENT;DEPENDS"
         )
 
-        # Set library path depending on the platform.
+        # Identify library path environment name depending on the platform.
         if (CMAKE_SYSTEM_NAME STREQUAL Windows)
-            set(LIB_ENV_PATH PATH)
-            set(_env_sep "\\\;")
+            set(LIBRARY_ENV_NAME PATH)
         elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-            set(LIB_ENV_PATH DYLD_LIBRARY_PATH)
-            set(_env_sep ":")
+            set(LIBRARY_ENV_NAME DYLD_LIBRARY_PATH)
         else()
-            set(LIB_ENV_PATH LD_LIBRARY_PATH)
-            set(_env_sep ":")
+            set(LIBRARY_ENV_NAME LD_LIBRARY_PATH)
         endif()
 
-        # Convert all paths into cmake paths.
-        cmake_path(CONVERT "$ENV{${LIB_ENV_PATH}}" TO_CMAKE_PATH_LIST libpath)
-        cmake_path(CONVERT "$ENV{PYTHONPATH}" TO_CMAKE_PATH_LIST pythonpath)
+        # Sanitize all paths for CMake.
+        cmake_path(CONVERT "$ENV{${LIBRARY_ENV_NAME}}" TO_CMAKE_PATH_LIST LIBRARY_PATH)
+        cmake_path(CONVERT "$ENV{PYTHONPATH}" TO_CMAKE_PATH_LIST PYTHON_PATH)
 
-        # Prepend input path to environment variables
+        # Prepend input path to environment variables.
         if (_LIBRARY_PATH_PREPEND)
             list(REVERSE _LIBRARY_PATH_PREPEND)
             foreach (_path ${_LIBRARY_PATH_PREPEND})
-                set(libpath "${_path}" "${libpath}")
+                set(LIBRARY_PATH "${_path}" "${LIBRARY_PATH}")
             endforeach()
         endif()
 
         if (_PYTHON_PATH_PREPEND)
             list(REVERSE _PYTHON_PATH_PREPEND)
             foreach (_path ${_PYTHON_PATH_PREPEND})
-                set(pythonpath "${_path}" "${pythonpath}")
+                set(PYTHON_PATH "${_path}" "${PYTHON_PATH}")
             endforeach()
         endif()
 
-        # Convert list into string.
-        list(JOIN libpath "${_env_sep}" libpath)
-        list(JOIN pythonpath "${_env_sep}" pythonpath)
-
+        # Default working directory to current build path if none is provided.
         if (NOT _WORKING_DIRECTORY)
             set(_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         endif()
@@ -116,9 +110,9 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             -D "PYTEST_EXECUTABLE=${PYTEST_EXECUTABLE}"
             -D "TEST_GROUP_NAME=${NAME}"
             -D "BUNDLE_TESTS=${_BUNDLE_TESTS}"
-            -D "LIB_ENV_PATH=${LIB_ENV_PATH}"
-            -D "LIBRARY_PATH=${libpath}"
-            -D "PYTHON_PATH=${pythonpath}"
+            -D "LIBRARY_ENV_NAME=${LIBRARY_ENV_NAME}"
+            -D "LIBRARY_PATH=${LIBRARY_PATH}"
+            -D "PYTHON_PATH=${PYTHON_PATH}"
             -D "TRIM_FROM_NAME=${_TRIM_FROM_NAME}"
             -D "WORKING_DIRECTORY=${_WORKING_DIRECTORY}"
             -D "ENVIRONMENT=${_ENVIRONMENT}"

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,10 +4,23 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Updated CMake script to ensure that environment variables are
+	preserving the Windows-style path syntax when running the tests.
+
+	.. seealso:: https://github.com/buddly27/pytest-cmake/issues/22
+
+    .. change:: changed
+
+	Improve tests.
+
 .. release:: 0.5.2
     :date: 2024-05-06
 
-   .. change:: fixed
+    .. change:: fixed
 
         Updated test collection logic to ensure that the 'rootdir' is a
         real path. Previously, running the tests from a symlinked directory

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,6 +6,10 @@ find_package(Python COMPONENTS Interpreter Development REQUIRED)
 set(_py_version ${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 mark_as_advanced(_py_version)
 
+if (WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+endif()
+
 find_package(Boost 1.70.0 COMPONENTS "python${_py_version}" REQUIRED)
 
 if (NOT TARGET Boost::python)

--- a/example/src/CMakeLists.txt
+++ b/example/src/CMakeLists.txt
@@ -1,9 +1,2 @@
-add_library(example MODULE main.cpp)
-
-set_target_properties(example PROPERTIES PREFIX "")
-
-if(WIN32)
-    set_target_properties(example PROPERTIES SUFFIX ".pyd")
-endif()
-
-target_link_libraries(example PUBLIC Boost::python Python::Python)
+add_subdirectory(foo)
+add_subdirectory(python)

--- a/example/src/foo/CMakeLists.txt
+++ b/example/src/foo/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(foo SHARED foo.cpp)
+
+target_include_directories(foo
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)

--- a/example/src/foo/foo.cpp
+++ b/example/src/foo/foo.cpp
@@ -1,0 +1,40 @@
+#include "./foo.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <stdexcept>
+
+Foo::Foo()
+{
+    const char* settings = std::getenv("FOO_SETTINGS_FILE");
+    if (settings == nullptr) {
+        throw std::runtime_error("Environment variable FOO_SETTINGS_FILE is not set.");
+    }
+
+    std::ifstream file(settings);
+    if (!file.is_open()) {
+        throw std::runtime_error("Unable to open Foo file.");
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string lang, greeting;
+        if (std::getline(iss, lang, ':') && std::getline(iss, greeting)) {
+            _map[lang] = greeting;
+        }
+    }
+    file.close();
+}
+
+std::string Foo::sayHello(std::string language)
+{
+    if (_map.find(language) == _map.end()) {
+        throw std::runtime_error("Language not found in Foo file.");
+    }
+
+    return _map[language];
+}

--- a/example/src/foo/foo.h
+++ b/example/src/foo/foo.h
@@ -1,0 +1,18 @@
+#ifndef EXAMPLE_FOO_H
+#define EXAMPLE_FOO_H
+
+#include <string>
+#include <unordered_map>
+
+class Foo {
+public:
+    Foo();
+    virtual ~Foo() = default;
+
+    std::string sayHello(std::string language);
+
+private:
+    std::unordered_map<std::string, std::string> _map;
+};
+
+#endif // EXAMPLE_FOO_H

--- a/example/src/python/CMakeLists.txt
+++ b/example/src/python/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(pyFoo MODULE main.cpp)
+
+set_target_properties(pyFoo
+    PROPERTIES
+        PREFIX ""
+        OUTPUT_NAME foo
+)
+
+if(WIN32)
+    set_target_properties(pyFoo PROPERTIES SUFFIX ".pyd")
+endif()
+
+target_link_libraries(pyFoo
+    PUBLIC
+        foo
+        Boost::python
+        Python::Python
+)
+
+if (WIN32)
+    # As of Python v3.8 and newer, DLLs are no longer searched for in the 
+    # PATH environment variable on Windows. Therefore, it is necessary to
+    # ensure that they are all located in the same directory.
+    add_custom_command(
+        TARGET pyFoo POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        -E copy_if_different
+        $<TARGET_FILE:foo>
+        $<TARGET_FILE_DIR:pyFoo>
+        COMMAND_EXPAND_LISTS
+    )
+endif()

--- a/example/src/python/main.cpp
+++ b/example/src/python/main.cpp
@@ -1,18 +1,21 @@
 #include <boost/python.hpp>
+#include <foo.h>
 
 #include <cstdlib>
 #include <string>
 
 std::string greet(std::string name)
 {
-    const char* value = std::getenv("GREETING_WORD");
+    Foo foo;
+
+    const char* value = std::getenv("DEFAULT_LANGUAGE");
     if (value != nullptr)
-        return std::string(value) + ", " + name;
+        return foo.sayHello(value) + ", " + name;
     else
-        return "bonjour, " + name;
+        return foo.sayHello("fr") + ", " + name;
 }
 
-BOOST_PYTHON_MODULE(example)
+BOOST_PYTHON_MODULE(foo)
 {
     using namespace boost::python;
     Py_Initialize();

--- a/example/test/CMakeLists.txt
+++ b/example/test/CMakeLists.txt
@@ -1,13 +1,13 @@
 pytest_discover_tests(
     PythonTest
     LIBRARY_PATH_PREPEND
-        $ENV{RUNNER_TEMP}
-        $<TARGET_FILE_DIR:example>
+        $<TARGET_FILE_DIR:foo>
+        $<TARGET_FILE_DIR:pyFoo>
     PYTHON_PATH_PREPEND
-        $ENV{RUNNER_TEMP}
-        $<TARGET_FILE_DIR:example>
+        $<TARGET_FILE_DIR:pyFoo>
     TRIM_FROM_NAME "^test_"
-    DEPENDS example
+    DEPENDS foo pyFoo
     ENVIRONMENT
-        "GREETING_WORD=hello"
+        "DEFAULT_LANGUAGE=en"
+        "FOO_SETTINGS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/resource/foo.txt"
 )

--- a/example/test/CMakeLists.txt
+++ b/example/test/CMakeLists.txt
@@ -1,8 +1,10 @@
 pytest_discover_tests(
     PythonTest
     LIBRARY_PATH_PREPEND
+        $ENV{RUNNER_TEMP}
         $<TARGET_FILE_DIR:example>
     PYTHON_PATH_PREPEND
+        $ENV{RUNNER_TEMP}
         $<TARGET_FILE_DIR:example>
     TRIM_FROM_NAME "^test_"
     DEPENDS example

--- a/example/test/resource/foo.txt
+++ b/example/test/resource/foo.txt
@@ -1,0 +1,3 @@
+en:hello
+fr:bonjour
+es:hola

--- a/example/test/subfolder/test_example2.py
+++ b/example/test/subfolder/test_example2.py
@@ -1,8 +1,18 @@
-# -*- coding: utf-8 -*-
+import foo
 
-import example
+import pytest
 
 
 def test_greet_michael():
     """Greet Michael."""
-    assert example.greet("Michael") == "hello, Michael"
+    assert foo.greet("Michael") == "hello, Michael"
+
+
+def test_greet_error(monkeypatch):
+    """Impossible to greet when FOO settings is not found."""
+    monkeypatch.delenv("FOO_SETTINGS_FILE")
+
+    with pytest.raises(RuntimeError) as error:
+        foo.greet("Michael")
+
+    assert "Environment variable FOO_SETTINGS_FILE is not set" in str(error.value)

--- a/example/test/test_example.py
+++ b/example/test/test_example.py
@@ -1,25 +1,28 @@
-# -*- coding: utf-8 -*-
-
-import example
+import foo
 
 
 def test_greet_world():
     """Greet the world."""
-    assert example.greet() == "hello, world"
+    assert foo.greet() == "hello, world"
 
 
 def test_greet_john():
     """Greet John."""
-    assert example.greet("John") == "hello, John"
+    assert foo.greet("John") == "hello, John"
 
 
 def test_greet_julia():
     """Greet Julia."""
-    assert example.greet("Julia") == "hello, Julia"
+    assert foo.greet("Julia") == "hello, Julia"
 
 
 def test_greet_julia_french(monkeypatch):
     """Greet Julia in French."""
-    monkeypatch.delenv("GREETING_WORD")
-    assert example.greet("Julia") == "bonjour, Julia"
+    monkeypatch.delenv("DEFAULT_LANGUAGE")
+    assert foo.greet("Julia") == "bonjour, Julia"
 
+
+def test_greet_julia_spanish(monkeypatch):
+    """Greet Julia in Spanish."""
+    monkeypatch.setenv("DEFAULT_LANGUAGE", "es")
+    assert foo.greet("Julia") == "hola, Julia"


### PR DESCRIPTION
As mentioned in #22, Unix-like paths are supported by most Windows-compatible shells, but it could be confusing to debug tests when backslashes are inverted. Therefore, the goal of the MR is to preserve Windows paths in environment variables.